### PR TITLE
Attempt to get the new location for the high res images from posts

### DIFF
--- a/keyring-facebook-importer/keyring-importer-facebook.php
+++ b/keyring-facebook-importer/keyring-importer-facebook.php
@@ -233,18 +233,9 @@ class Keyring_Facebook_Importer extends Keyring_Importer_Base {
 				$photos = array();
 
 				if ( isset( $post->picture ) ) {
-					// The API returns the tiniest thumbnail. Unacceptable.
-					if ( $post->type == 'link' ) {
-						$photos[] = urldecode( preg_replace( '%https://fbexternal-a\.akamaihd\.net/safe_image\.php\?d=[A-Z0-9a-z\-_]+&w=[0-9]+&h=[0-9]+&url=%', '', $post->picture ) );
-					} else {
-						$picture = preg_replace( '/_s\./', '_n.',  $post->picture );
-						$high_res = preg_replace( '/\/s\d\d\dx\d\d\d\//', '/',  $picture );
-						if (stripos(get_headers($high_res)[0], '200') !== false) {
-							$photos[] = $high_res;
-						} else {
-							$photos[] = $picture;
-						}
-					}
+					// The API returns the tiniest thumbnail. Unacceptable
+					$picture_object = $this->service->request('https://graph.facebook.com/' . $post->object_id);
+					$photos[] = $picture_object->source;
 				}
 			}
 


### PR DESCRIPTION
Facebook has changed the location for high res photos. It a lot of cases you can simply remove a part of the URL in the form

/s130x130/

However, this isn't always the case. I've seen some URLs with a /q80/ part that is needed and sometimes the sXXXxXXX needs replacing with a different value.

This is why there's a test on the headers of the new URL before setting it as the photo. If the headers don't return a 200 response then the original image returned from Facebook is used.
