### PR TITLE
Given that "read_stream" is now in Deprecated Permissions of Facebook…

### DIFF
--- a/keyring-facebook-importer/keyring-importer-facebook.php
+++ b/keyring-facebook-importer/keyring-importer-facebook.php
@@ -665,7 +665,7 @@ add_action( 'init', function() {
 } );
 
 add_filter( 'keyring_facebook_scope', function ( $scopes ) {
-	$scopes[] = 'read_stream';
+	$scopes[] = 'user_posts';
 	$scopes[] = 'user_photos';
 	$scopes[] = 'manage_pages';
 	return $scopes;


### PR DESCRIPTION
… as per https://developers.facebook.com/docs/facebook-login/permissions#reference-read_stream

Then have moved to using "user_posts" instead.